### PR TITLE
Decode path before searching on s3

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -94,6 +94,8 @@ function serveList(prefixes, res){
 
 app.use(function(req, res, next){
   var path = prefix + req.path.substr(1);
+  path = path.replace(/\+/g, '%20');
+  path = decodeURIComponent(path);
 
   if(path === '' || path.slice(-1) === '/'){
     loadPrefixes(path, function(err, data){


### PR DESCRIPTION
# Description

When trying to access a filename with spaces, it returns 404.

<details>
<summary>Requests with path containing + sign as space separator</summary>

![image](https://user-images.githubusercontent.com/11169832/93376122-85ca4b00-f82f-11ea-8a91-f377e2218a4d.png)
</details>

<details>

<summary>Requests with path containing %20 sign as space separator</summary>

![image](https://user-images.githubusercontent.com/11169832/93376302-c629c900-f82f-11ea-809c-4b62d6ba7fad.png)
</details>